### PR TITLE
Scale guided dash lines based on current zoom level

### DIFF
--- a/Code/LineModes/LineBase.cs
+++ b/Code/LineModes/LineBase.cs
@@ -288,17 +288,16 @@ namespace LineTool
                 float3 offset = (segment.b - segment.a) * (lineScaleModifier * 5f / distance);
                 Line3.Segment line = new (segment.a + offset, segment.b - offset);
 
-                // Measurements for dashed line: length of dash, gap between them, and drawn width
+                // Measurements for dashed line: length of dash, width of dash, and gap between them
                 float lineDashLength = lineScaleModifier * 5f;
-                float lineGapWidth = lineScaleModifier * 3f;
                 float lineDashWidth = lineScaleModifier * 3f;
+                float lineGapLength = lineScaleModifier * 3f;
 
                 // Draw line - distance figures mimic game simple curve overlay.
-                overlayBuffer.DrawDashedLine(Color.white, line, lineDashWidth, lineDashLength, lineGapWidth);
+                overlayBuffer.DrawDashedLine(Color.white, line, lineDashWidth, lineDashLength, lineGapLength);
 
                 // Add length tooltip.
                 int length = Mathf.RoundToInt(math.distance(startPos.xz, endPos.xz));
-
                 if (length > 0)
                 {
                     tooltips.Add(new TooltipInfo(TooltipType.Length, (startPos + endPos) * 0.5f, length));

--- a/Code/LineModes/SimpleCurve.cs
+++ b/Code/LineModes/SimpleCurve.cs
@@ -223,7 +223,8 @@ namespace LineTool
         /// </summary>
         /// <param name="overlayBuffer">Overlay buffer.</param>
         /// <param name="tooltips">Tooltip list.</param>
-        public override void DrawOverlay(OverlayRenderSystem.Buffer overlayBuffer, NativeList<TooltipInfo> tooltips)
+        /// <param name="cameraController">Current camera controller.</param>
+        public override void DrawOverlay(OverlayRenderSystem.Buffer overlayBuffer, NativeList<TooltipInfo> tooltips, CameraUpdateSystem cameraController)
         {
             if (m_validStart)
             {
@@ -235,8 +236,8 @@ namespace LineTool
                     Line3.Segment line2 = new (_elbowPoint, m_endPos);
 
                     // Draw lines.
-                    DrawDashedLine(m_startPos, _elbowPoint, line1, overlayBuffer, tooltips);
-                    DrawDashedLine(_elbowPoint, m_endPos, line2, overlayBuffer, tooltips);
+                    DrawDashedLine(m_startPos, _elbowPoint, line1, overlayBuffer, tooltips, cameraController);
+                    DrawDashedLine(_elbowPoint, m_endPos, line2, overlayBuffer, tooltips, cameraController);
 
                     // Draw angle.
                     DrawAngleIndicator(line1, line2, 8f, 8f, overlayBuffer, tooltips);
@@ -244,7 +245,7 @@ namespace LineTool
                 else
                 {
                     // Initial position only; just draw a straight line (constrained if required).
-                    base.DrawOverlay(overlayBuffer, tooltips);
+                    base.DrawOverlay(overlayBuffer, tooltips, cameraController);
                 }
             }
         }

--- a/Code/Systems/LineToolSystem.cs
+++ b/Code/Systems/LineToolSystem.cs
@@ -67,6 +67,7 @@ namespace LineTool
         private TerrainHeightData _terrainHeightData;
         private OverlayRenderSystem.Buffer _overlayBuffer;
         private CityConfigurationSystem _cityConfigurationSystem;
+        private CameraUpdateSystem _cameraController;
 
         // Input actions.
         private ProxyAction _applyAction;
@@ -446,6 +447,7 @@ namespace LineTool
             _terrainSystem = World.GetOrCreateSystemManaged<TerrainSystem>();
             _overlayBuffer = World.GetOrCreateSystemManaged<OverlayRenderSystem>().GetBuffer(out var _);
             _cityConfigurationSystem = World.GetOrCreateSystemManaged<CityConfigurationSystem>();
+            _cameraController = World.GetOrCreateSystemManaged<CameraUpdateSystem>();
 
             // Create buffers.
             _tooltips = new (8, Allocator.Persistent);
@@ -622,7 +624,7 @@ namespace LineTool
             }
 
             // Render any overlay.
-            _mode.DrawOverlay(_overlayBuffer, _tooltips);
+            _mode.DrawOverlay(_overlayBuffer, _tooltips, _cameraController);
 
             // Overlay control points.
             if (_fixedPreview)


### PR DESCRIPTION
### Context

The dashed lines had fixed dimensions and were less helpful when zoomed in really close or really far away. When zoomed in close with smaller props, the dashed line makes it difficult to see and measure.

### Proposal

The line's width, length, and gap are now multiplied by a constant "scaling" factor that renders the line dynamically as a player zooms in or out. The `lineScaleModifier` is calculated by `(z * 0.0025) + 0.1` where z is the gameplay's current zoom level. Zoomed in all the way is _10_; out all the way is _10,000_.

My first stab at cs2 mod dev and would love any feedback!

Screenshots with PR branch's changes compiled in the after column:

| Before (zoomed in) | After (zoomed in) |
| --- | --- |
| ![cs2_linetool_zoom_in_before](https://github.com/algernon-A/LineTool-CS2/assets/6655673/5c7f9af8-73e3-47ce-9f62-05ee6fc6fb1b) | ![cs2_linetool_zoom_in_after](https://github.com/algernon-A/LineTool-CS2/assets/6655673/bc3e5313-b7a6-4b59-a943-5ce7cb3fb76b) |

| Before (zoomed out) | After (zoomed out) |
| --- | --- |
| ![cs2_linetool_zoom_out_before](https://github.com/algernon-A/LineTool-CS2/assets/6655673/68f5c677-1165-4aa0-be11-14cb9cd244c0) | ![cs2_linetool_zoom_out_after](https://github.com/algernon-A/LineTool-CS2/assets/6655673/eb1f6918-23ab-4e91-b704-0e93d39199c0) |

