### PR TITLE
Add curved overlays, circle overlays, and semi-transparent color

### DIFF
--- a/Code/LineModes/Circle.cs
+++ b/Code/LineModes/Circle.cs
@@ -119,6 +119,9 @@ namespace LineTool
                 {
                     DrawCurvedDashedLine(_thisCircleBeziers[i], overlayBuffer, cameraController);
                 }
+
+                // Keep straight line with distance tooltip.
+                base.DrawOverlay(overlayBuffer, tooltips, cameraController);
             }
             else
             {

--- a/Code/LineModes/LineBase.cs
+++ b/Code/LineModes/LineBase.cs
@@ -264,7 +264,7 @@ namespace LineTool
         }
 
         /// <summary>
-        /// Draws a dashed line overlay between the two given points.
+        /// Draws a straight dashed line overlay between the two given points.
         /// </summary>
         /// <param name="startPos">Line start position.</param>
         /// <param name="endPos">Line end position.</param>
@@ -274,6 +274,9 @@ namespace LineTool
         /// <param name="cameraController">Active camera controller instance.</param>
         protected void DrawDashedLine(float3 startPos, float3 endPos, Line3.Segment segment, OverlayRenderSystem.Buffer overlayBuffer, List<TooltipInfo> tooltips, CameraUpdateSystem cameraController)
         {
+            // Semi-transparent white color
+            Color color = new Color(1f, 1f, 1f, 0.6f);
+
             // Dynamically scale dashed line based on current gameplay camera zoom level; vanilla range min:10f max:10000f.
             float currentZoom = cameraController.zoom;
             float lineScaleModifier = (currentZoom * 0.0025f) + 0.1f;
@@ -287,13 +290,13 @@ namespace LineTool
                 float3 offset = (segment.b - segment.a) * (lineScaleModifier * 5f / distance);
                 Line3.Segment line = new (segment.a + offset, segment.b - offset);
 
-                // Measurements for dashed line: length of dash, width of dash, and gap between them
+                // Measurements for dashed line: length of dash, width of dash, and gap between them.
                 float lineDashLength = lineScaleModifier * 5f;
                 float lineDashWidth = lineScaleModifier * 3f;
                 float lineGapLength = lineScaleModifier * 3f;
 
                 // Draw line - distance figures mimic game simple curve overlay.
-                overlayBuffer.DrawDashedLine(Color.white, line, lineDashWidth, lineDashLength, lineGapLength);
+                overlayBuffer.DrawDashedLine(color, line, lineDashWidth, lineDashLength, lineGapLength);
 
                 // Add length tooltip.
                 int length = Mathf.RoundToInt(math.distance(startPos.xz, endPos.xz));
@@ -302,6 +305,30 @@ namespace LineTool
                     tooltips.Add(new TooltipInfo(TooltipType.Length, (startPos + endPos) * 0.5f, length));
                 }
             }
+        }
+
+        /// <summary>
+        /// Draws a curved dashed line overlay along the given Bezier curve.
+        /// </summary>
+        /// <param name="curve">Line curve segment.</param>
+        /// <param name="overlayBuffer">Overlay buffer.</param>
+        /// <param name="cameraController">Active camera controller instance.</param>
+        protected void DrawCurvedDashedLine(Bezier4x3 curve, OverlayRenderSystem.Buffer overlayBuffer, CameraUpdateSystem cameraController)
+        {
+            // Semi-transparent white color.
+            Color color = new Color(1f, 1f, 1f, 0.6f);
+
+            // Dynamically scale dashed line based on current gameplay camera zoom level; vanilla range min:10f max:10000f.
+            float currentZoom = cameraController.zoom;
+            float lineScaleModifier = (currentZoom * 0.0025f) + 0.1f;
+
+            // Measurements for dashed line: length of dash, width of dash, and gap between them.
+            float lineDashLength = lineScaleModifier * 4f;
+            float lineDashWidth = lineScaleModifier * 1f;
+            float lineGapLength = lineScaleModifier * 3f;
+
+            // Draw line - distance figures mimic game simple curve overlay.
+            overlayBuffer.DrawDashedCurve(color, curve, lineDashWidth, lineDashLength, lineGapLength);
         }
 
         /// <summary>

--- a/Code/LineModes/SimpleCurve.cs
+++ b/Code/LineModes/SimpleCurve.cs
@@ -245,6 +245,9 @@ namespace LineTool
 
                     // Draw angle.
                     DrawAngleIndicator(line1, line2, 8f, 8f, overlayBuffer, tooltips);
+
+                    // Draw curved line.
+                    DrawCurvedDashedLine(_thisBezier, overlayBuffer, cameraController);
                 }
                 else
                 {


### PR DESCRIPTION
Appreciate all of the help so far! If not having curved overlay lines was intentional, I apologize - you can delete this PR. I'm just learning/practicing the mod dev workflow and your mod was the perfect starting place 😄 

### Proposal

Add two dashed line overlays:

- Simple Curve Tool : adds a smaller/thinner dashed overlay line following the curve. The two elbow lines and angle overlay are untouched.
- Circle Tool : creates a curved circle line overlay using the game's Circle Bezier function. This creates 1/4th of a circle on a curve, so four Beziers are combined in a fixed-length array and drawn together to form a circle.

Also changed the color to be semi transparent. This is to help when using the tool to draw lines on top of something so you can somewhat see underneath.

### Simple Curve Tool
| Before | After |
| --- | --- |
| ![cs2_linetool_curve_before](https://github.com/algernon-A/LineTool-CS2/assets/6655673/a9c13304-fdba-4faf-9356-8b615170c2fa)  | ![cs2_linetool_curve_after](https://github.com/algernon-A/LineTool-CS2/assets/6655673/91aa82be-c4eb-4f17-a731-38c02f858229) |


### Circle Tool

| Before | After  |
| --- | --- |
| ![cs2_linetool_circle_before](https://github.com/algernon-A/LineTool-CS2/assets/6655673/dc100299-89ad-4821-b45d-706a8ca98d37) | ![cs2_linetool_circle_after](https://github.com/algernon-A/LineTool-CS2/assets/6655673/3518010a-3a41-408e-b81b-a3814bb0b0ea) |



