### PR TITLE
Angle adjustment overlays and other overlay bug fixes

### DIFF
--- a/Code/LineModes/Circle.cs
+++ b/Code/LineModes/Circle.cs
@@ -112,21 +112,19 @@ namespace LineTool
         /// <param name="cameraController">Active camera controller instance.</param>
         public override void DrawOverlay(OverlayRenderSystem.Buffer overlayBuffer, List<TooltipInfo> tooltips, CameraUpdateSystem cameraController)
         {
-            // If points haven't been calculated yet, fallback to straight line.
-            if (_thisCircleBeziers[0].a.x != 0f)
-            {
-                for (int i = 0; i < _thisCircleBeziers.Length; i++)
-                {
-                    DrawCurvedDashedLine(_thisCircleBeziers[i], overlayBuffer, cameraController);
-                }
-
-                // Keep straight line with distance tooltip.
-                base.DrawOverlay(overlayBuffer, tooltips, cameraController);
-            }
-            else
+            if (m_validStart)
             {
                 // Initial position only; just draw a straight line (constrained if required).
                 base.DrawOverlay(overlayBuffer, tooltips, cameraController);
+
+                // If points haven't been calculated yet, fallback to straight line.
+                if (_thisCircleBeziers[0].a.x != 0f)
+                {
+                    for (int i = 0; i < _thisCircleBeziers.Length; i++)
+                    {
+                        DrawCurvedDashedLine(_thisCircleBeziers[i], overlayBuffer, cameraController);
+                    }
+                }
             }
         }
 

--- a/Code/LineModes/SimpleCurve.cs
+++ b/Code/LineModes/SimpleCurve.cs
@@ -283,6 +283,7 @@ namespace LineTool
             if (_validElbow)
             {
                 _validElbow = false;
+                _thisBezier = new Bezier4x3();
             }
             else
             {
@@ -596,17 +597,17 @@ namespace LineTool
                 double angleRadians = math.acos(math.dot(normalizedVector1, normalizedVector2));
                 int angleDegrees = (int)math.round(math.degrees(angleRadians));
 
-                // Set overlay joints fixed distance along both lines.
-                float3 overlayJoint1 = line1.b + (normalizedVector1 * overlayLineDistance);
-                float3 overlayJoint2 = line1.b + (normalizedVector2 * overlayLineDistance);
-
                 // Calculate vector split down the middle (using vector addition parallelogram method).
                 float3 overlayJointS = line1.b + ((normalizedVector1 + normalizedVector2) * overlayLineDistance);
 
+                // Calculate joints where angle guidelines will connect at.
+                float3 overlayJoint1 = line1.b + (normalizedVector1 * overlayLineDistance);
+                float3 overlayJoint2 = line1.b + (normalizedVector2 * overlayLineDistance);
+
                 if (angleDegrees == 90)
                 {
-                    overlayBuffer.DrawLine(color, new Line3.Segment(overlayJoint1, overlayJointS), overlayLineWidth * 2f);
-                    overlayBuffer.DrawLine(color, new Line3.Segment(overlayJointS, overlayJoint2), overlayLineWidth * 2f);
+                    // Set joints inbetween and then draw full width line as "box".
+                    overlayBuffer.DrawLine(color, new Line3.Segment((overlayJoint1 + line1.b) / 2, (overlayJointS + overlayJoint2) / 2), overlayLineDistance);
                 }
                 else
                 {


### PR DESCRIPTION
### Changes

- Removed fixed min length of 55m for angle overlay indicator, dynamically draw angle overlay based on zoom/length.
- Refactored the DrawAngleIndicator method. I noticed there was a ton of math for determining directionality. By drawing a parallelogram split vector, we can find the "joint" where the angle indicator draws to (or right angle corners to).
- Fixed a bug with the Circle overlay: clearing a selection with tool active, hover over toolbar ui, notice the circle guidelines re-appear.
- Fixed a bug with the Simple Curve overlay: clearing a selection to remove elbow, then choosing a new elbow, the old curve overlay flashes for a split second. Since DrawOverlay is called before CalculatePoints, it seemed like clearing the bezier on Reset was the easiest solution but always open to suggestions.
- Moved angle tooltip to be offset opposite of inside of curve, that way it isn't on top of other ui elements.

| Before | After |
| --- | --- |
| ![Screenshot (34)](https://github.com/algernon-A/LineTool-CS2/assets/6655673/771e6ab1-9df9-4fb9-b0d9-c7ba5b27ca3f)   |  ![Screenshot (37)](https://github.com/algernon-A/LineTool-CS2/assets/6655673/5cfe56a0-c16b-4ac4-97df-031d677ede09)  |
|  ![Screenshot (35)](https://github.com/algernon-A/LineTool-CS2/assets/6655673/a66c3087-09d7-4541-a9cf-cac2768b3bc2)  |  ![Screenshot (38)](https://github.com/algernon-A/LineTool-CS2/assets/6655673/1b699a1d-889e-4d0d-b703-349834f2d062)  |
|  ![Screenshot (36)](https://github.com/algernon-A/LineTool-CS2/assets/6655673/278746a9-3a11-4d01-89e9-4d8911e0f02a)  | ![Screenshot (39)](https://github.com/algernon-A/LineTool-CS2/assets/6655673/e7912530-15af-417f-8120-45351133599b) |









