### PR TITLE
Refresh ALT guideline overlay colors from Hover Colors before drawing

### DIFF
--- a/Code/LineModes/LineBase.cs
+++ b/Code/LineModes/LineBase.cs
@@ -282,6 +282,19 @@ namespace LineTool
         }
 
         /// <summary>
+        /// Refreshes guideline rendering colors from the shared game settings.
+        /// </summary>
+        /// <param name="highPriorityColor">High priority line colour.</param>
+        /// <param name="mediumPriorityColor">Medium priority line colour.</param>
+        /// <param name="distanceScale">Line width distance scale.</param>
+        internal void UpdateGuideLineSettings(Color highPriorityColor, Color mediumPriorityColor, float distanceScale)
+        {
+            m_highPriorityColor = highPriorityColor;
+            m_mediumPriorityColor = mediumPriorityColor;
+            m_distanceScale = distanceScale;
+        }
+
+        /// <summary>
         /// Applies any active constraints to the given world position.
         /// </summary>
         /// <param name="currentPos">World position to constrain.</param>

--- a/Code/Systems/LineToolSystem.cs
+++ b/Code/Systems/LineToolSystem.cs
@@ -645,7 +645,6 @@ namespace LineTool
             _keepBuildingAction.AddCompositeBinding("ButtonWithOneModifier").With("Modifier", "<Keyboard>/shift").With("Button", "<Mouse>/leftButton");
             _keepBuildingAction.Enable();
 
-  
             // Load ALT guideline transparency only when Hover Colors is not managing guideline opacity.
             GuidelineTransparency = CompatibilityHoverColors.IsHoverColorsLoaded()
                 ? 0f
@@ -854,13 +853,17 @@ namespace LineTool
             }
 
             // Render any overlay (inverting transparency to alpha).
-            // Guard rare case: if Hover Colors is loaded, keep ALT's overlay at full alpha so
-            // ALT's saved transparency setting does not additionally dim the guideline.
-            float effectiveGuidelineTransparency = CompatibilityHoverColors.IsHoverColorsLoaded()
-                ? 0f
-                : GuidelineTransparency;
+            float overlayAlpha = 1f - GuidelineTransparency;
+            if (CompatibilityHoverColors.IsHoverColorsLoaded())
+            {
+                // Hover Colors manages GuideLineSettingsData; refresh each draw so ALT doesn't
+                // keep stale cached colors, and preserve HC's own dashed-line alpha.
+                GuideLineSettingsData guideLineSettings = _renderingSettingsQuery.GetSingleton<GuideLineSettingsData>();
+                _mode.UpdateGuideLineSettings(guideLineSettings.m_HighPriorityColor, guideLineSettings.m_MediumPriorityColor, _objectToolSystem.distanceScale);
+                overlayAlpha = guideLineSettings.m_HighPriorityColor.a;
+            }
 
-            _mode.DrawOverlay(1f - effectiveGuidelineTransparency, _overlayBuffer, _tooltips);
+            _mode.DrawOverlay(overlayAlpha, _overlayBuffer, _tooltips);
 
             // Overlay control points.
             if (_fixedPreview)

--- a/Code/Systems/LineToolSystem.cs
+++ b/Code/Systems/LineToolSystem.cs
@@ -853,14 +853,21 @@ namespace LineTool
             }
 
             // Render any overlay (inverting transparency to alpha).
-            float overlayAlpha = 1f - GuidelineTransparency;
-            if (CompatibilityHoverColors.IsHoverColorsLoaded())
+            bool hoverColorsLoaded = CompatibilityHoverColors.IsHoverColorsLoaded();
+            float overlayAlpha;
+            if (hoverColorsLoaded)
             {
                 // Hover Colors manages GuideLineSettingsData; refresh each draw so ALT doesn't
                 // keep stale cached colors, and preserve HC's own dashed-line alpha.
                 GuideLineSettingsData guideLineSettings = _renderingSettingsQuery.GetSingleton<GuideLineSettingsData>();
                 _mode.UpdateGuideLineSettings(guideLineSettings.m_HighPriorityColor, guideLineSettings.m_MediumPriorityColor, _objectToolSystem.distanceScale);
-                overlayAlpha = guideLineSettings.m_HighPriorityColor.a;
+                overlayAlpha = math.clamp(guideLineSettings.m_HighPriorityColor.a, 0f, 1f);
+            }
+            else
+            {
+                // Without Hover Colors, ALT's own Options slider stays authoritative.
+                GuidelineTransparency = Mod.Instance.ActiveSettings.GuidelineTransparency;
+                overlayAlpha = math.clamp(1f - GuidelineTransparency, 0f, 1f);
             }
 
             _mode.DrawOverlay(overlayAlpha, _overlayBuffer, _tooltips);


### PR DESCRIPTION
**Changes**
- Refresh ALT guideline colors from `GuideLineSettingsData` before drawing when Hover Colors is installed.
- Use HC's current dashed guideline alpha instead of forcing ALT overlay alpha to full opacity.
- Keep ALT's own guideline transparency slider authoritative when HC is not installed.

**Reason**
ALT reads guideline colors and stores them in the active `LineBase` mode.
This change makes ALT refresh from the current shared guideline data before drawing, so ALT follows HC changes reliably.

Has HC installed path
Has ALT Alone / No HC path
has LineBase.cs helper method that refreshes ALT's cached colors:
`internal void UpdateGuideLineSettings(Color highPriorityColor, Color mediumPriorityColor, float distanceScale)`
